### PR TITLE
Update to Node 12.8.4 due to security release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ defaults:
           COMMIT_SHA1="${CIRCLE_SHA1:0:7}"
           VERSION="${CIRCLE_TAG:=$CIRCLE_BRANCH}-${CIRCLE_SHA1:0:7}"
           BRANCH=(${CIRCLE_BRANCH/-/ })
-          NODE_VERSION="12.18.0"
+          NODE_VERSION="12.18.4"
           set +a
           EOF
     - log_in_to_quay: &log_in_to_quay
@@ -25,7 +25,7 @@ jobs:
       CIRCLE_REVERSE_DEPENDENCIES: meteoros spm cipher oauthd-service
     docker:
       - image: cibuilds/docker:18.09.6
-    steps: 
+    steps:
       - checkout
       - setup_remote_docker
       - run: *set_environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,40 @@
 FROM quay.io/redsift/baseos
 LABEL author.name="Karl Norling" \
   author.email="karl@redsift.io" \
-  version="1.1.103" \
+  version="1.1.104" \
   organization="Red Sift"
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
-    apt-get update && \
-    apt-get install -y curl \
-        libpython-stdlib libpython2.7-minimal libpython2.7-stdlib mime-support python python-minimal python2.7 python2.7-minimal python-pip git && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+  apt-get update && \
+  apt-get install -y curl \
+  libpython-stdlib libpython2.7-minimal libpython2.7-stdlib mime-support python python-minimal python2.7 python2.7-minimal python-pip git && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ARG nv="12.18.0"
+ARG nv="12.18.4"
 
 ENV NVM_VERSION 0.35.3
 ENV NVM_DIR ${HOME}/.nvm
 ENV NODE_VERSION "${nv}"
-ENV NPM_VERSION 6.14.4
+ENV NPM_VERSION 6.14.6
 
 # node has dropped http header size from 80K to 8K
 ENV NODE_OPTIONS='--max-http-header-size=81000 --trace-warnings'
 
 # Install nvm with node and npm
 RUN curl https://raw.githubusercontent.com/creationix/nvm/v$NVM_VERSION/install.sh | bash \
-    && . $NVM_DIR/nvm.sh \
-    && nvm install $NODE_VERSION \
-    && nvm alias default $NODE_VERSION \
-    && nvm use default \
-    && npm i -g npm@$NPM_VERSION \
-    && npm_config_user=root npm install -g bunyan --quiet
+  && . $NVM_DIR/nvm.sh \
+  && nvm install $NODE_VERSION \
+  && nvm alias default $NODE_VERSION \
+  && nvm use default \
+  && npm i -g npm@$NPM_VERSION \
+  && npm_config_user=root npm install -g bunyan --quiet
 
 ENV NODE_PATH $NVM_DIR/versions/node/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
 # Version dump
 RUN echo "NodeJS" `node -v` && \
-    echo "NPM" `npm -v`
+  echo "NPM" `npm -v`
 
 # Define working directory.
 WORKDIR /


### PR DESCRIPTION
Updates are now available for v10,x, v12.x and v14.x Node.js release lines for the following issues.

### HTTP Request Smuggling due to CR-to-Hyphen conversion (High) (CVE-2020-8201)

Affected Node.js versions converted carriage returns in HTTP request headers to a hyphen before parsing. This can lead to HTTP Request Smuggling as it is a non-standard interpretation of the header.

Impacts:
* All versions of the 14.x and 12.x releases lines

Thank you to Amit Klein who works at Safebreach for reporting this vulnerability.

### Denial of Service by resource exhaustion CWE-400 due to unfinished HTTP/1.1 requests (Critical) (CVE-2020-8251)

Node.js is vulnerable to HTTP denial of service (DOS) attacks based on delayed requests submission which can make the server unable to accept new connections. The fix a new http.Server option called requestTimeout
with a default value of 0 which means it is disabled by default. This should be set when Node.js is used as an edge server, for more details refer to the documentation.

Impacts:
* All versions of the 14.x release line

Thank you to Paolo Insogna and Matteo Collina who work at NearFom for reporting and fixing this vulnerability.

### fs.realpath.native on may cause buffer overflow (Medium) (CVE-2020-8252)

libuv's realpath implementation incorrectly determined the buffer size which can result in a buffer overflow if the resolved path is longer than 256 bytes.

Impacts:

* All versions of the 10.x release line
* All versions of the 12.x release line
* All versions of the 14.x release line before 14.9.0

## Downloads and release details

* [Node.js v10.22.1 (LTS)](https://nodejs.org/en/blog/release/v10.22.1/)
* [Node.js v12.18.4 (LTS)](https://nodejs.org/en/blog/release/v12.18.4/)
* [Node.js v14.11.0 (Current)](https://nodejs.org/en/blog/release/v14.11.0/)
